### PR TITLE
A possible fix for the InheritedConnectionError

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -295,6 +295,10 @@ module RedisFailover
       logger.debug("Fetched nodes: #{nodes}")
 
       nodes
+    rescue Zookeeper::Exceptions::InheritedConnectionError => e
+      logger.deubg { "d'oh! caught #{e.class} '#{e.message}' reconstructing the zk instance" }
+      @zk.reopen
+      retry
     end
 
     # Builds new Redis clients for the specified nodes.


### PR DESCRIPTION
It would probably be better to proactively call reopen on the zk instance,
but this might be a good action in response to this particular exception
being raised. re: ryanlecompte/redis_failover#15
