### PR TITLE
Support for environments

### DIFF
--- a/lib/redis_failover/cli.rb
+++ b/lib/redis_failover/cli.rb
@@ -40,6 +40,10 @@ module RedisFailover
           options[:config_file] = file
         end
 
+        opts.on '-E', '--environment ENV', 'Config environment to use' do |config_env|
+          options[:config_environment] = config_env
+        end
+
         opts.on('-h', '--help', 'Display all options') do
           puts opts
           exit
@@ -48,7 +52,7 @@ module RedisFailover
 
       parser.parse(source)
       if config_file = options[:config_file]
-        options = from_file(config_file)
+        options = from_file(config_file, options[:config_environment])
       end
 
       if required_options_missing?(options)
@@ -69,12 +73,16 @@ module RedisFailover
     # Parses options from a YAML file.
     #
     # @param [String] file the filename
+    # @params [String] _env the environment
     # @return [Hash] the parsed options
-    def self.from_file(file)
+    def self.from_file(file, _env=nil)
       unless File.exists?(file)
         raise ArgumentError, "File #{file} can't be found"
       end
       options = YAML.load_file(file)
+      if _env && !(options = options[_env.intern])
+        raise ArgumentError, "Environment #{_env} can't be found in config"
+      end
       options[:nodes] = options[:nodes].join(',')
       options[:zkservers] = options[:zkservers].join(',')
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -35,6 +35,17 @@ module RedisFailover
           '1'])
         opts[:max_failures].should == 1
       end
+
+      it 'properly parses the config file' do
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/single_environment.yml"])
+        opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
+
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/multiple_environments.yml", '-E', 'development'])
+        opts[:zkservers].should == 'localhost:2181'
+
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/multiple_environments.yml", '-E', 'staging'])
+        opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
+      end
     end
   end
 end

--- a/spec/support/config/multiple_environments.yml
+++ b/spec/support/config/multiple_environments.yml
@@ -1,0 +1,15 @@
+:development:
+  :nodes:
+    - localhost:6379
+    - localhost:6389
+  :zkservers:
+    - localhost:2181
+
+:staging:
+  :nodes:
+    - redis01:6379
+    - redis02:6379
+  :zkservers:
+    - zk01:2181
+    - zk02:2181
+    - zk03:2181

--- a/spec/support/config/single_environment.yml
+++ b/spec/support/config/single_environment.yml
@@ -1,0 +1,7 @@
+:nodes:
+  - redis01:6379
+  - redis02:6379
+:zkservers:
+  - zk01:2181
+  - zk02:2181
+  - zk03:2181


### PR DESCRIPTION
Hi,

I've added support to optionally use multiple environments in the config. This makes it possible to share one config file between the client/application and the redis_node_manager in multiple environments.

Regards
Ole
