### PR TITLE
adding $stdout.sync in redis_node_manager

### DIFF
--- a/bin/redis_node_manager
+++ b/bin/redis_node_manager
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$stdout.sync = true
 require 'redis_failover'
 
 RedisFailover::Runner.run(ARGV)


### PR DESCRIPTION
Hi, @ryanlecompte

I need to output to log file.
e.g)
nohup redis_node_manager -n aaaaaaa,bbbbbb -z cccccc,ddddddd,eeeeee > foo.log &

But the stdout is buffering, I cannot get last logs.
And the last logs outs when shutting down the node manager, though.

It requests can immediate output to log file.
It's so simple.

Prealse merge it if you like.
