### PR TITLE
Updated gem versions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 0.8.5
 -----------
 - Lock-down gemspec to version 1.1.x of redis-namespace to play nicely with redis 2.2.x.
+- Fix RedisFailover::Client#manual_failover regression (oleriesenberg)
 
 0.8.4
 -----------

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+HEAD
+-----------
+- Lock-down gemspec to version 1.1.x of redis-namespace to play nicely with redis 2.2.x.
+
 0.8.4
 -----------
 - Lock-down gemspec to redis 2.2.x in light of upcoming redis 3.x release. Once sufficient testing

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-HEAD
+0.8.5
 -----------
 - Lock-down gemspec to version 1.1.x of redis-namespace to play nicely with redis 2.2.x.
 

--- a/bin/redis_node_manager
+++ b/bin/redis_node_manager
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$stdout.sync = true
 require 'redis_failover'
 
 RedisFailover::Runner.run(ARGV)

--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -146,7 +146,7 @@ module RedisFailover
     # @option options [String] :host the host of the failover candidate
     # @option options [String] :port the port of the failover candidate
     def manual_failover(options = {})
-      ManualFailover.new(zk, options).perform
+      ManualFailover.new(@zk, options).perform
       self
     end
 

--- a/lib/redis_failover/version.rb
+++ b/lib/redis_failover/version.rb
@@ -1,3 +1,3 @@
 module RedisFailover
-  VERSION = '0.8.4'
+  VERSION = '0.8.5'
 end

--- a/redis_failover.gemspec
+++ b/redis_failover.gemspec
@@ -24,4 +24,3 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('yard')
 end
-

--- a/redis_failover.gemspec
+++ b/redis_failover.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = RedisFailover::VERSION
 
   gem.add_dependency('redis', '~> 3.0')
-  gem.add_dependency('redis-namespace')
+  gem.add_dependency('redis-namespace', '~> 1.1')
   gem.add_dependency('multi_json', '~> 1')
   gem.add_dependency('zk', '~> 1.6')
 

--- a/redis_failover.gemspec
+++ b/redis_failover.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = RedisFailover::VERSION
 
-  gem.add_dependency('redis', '~> 2.2')
+  gem.add_dependency('redis', '~> 3.0')
   gem.add_dependency('redis-namespace')
   gem.add_dependency('multi_json', '~> 1')
-  gem.add_dependency('zk', '~> 1.4')
+  gem.add_dependency('zk', '~> 1.6')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rspec')

--- a/redis_failover.gemspec
+++ b/redis_failover.gemspec
@@ -24,3 +24,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('yard')
 end
+


### PR DESCRIPTION
I've been testing the newer gem versions and they seem to work like a charm. Also, zookeeper failover is working with a setup of 2 Redis nodes and 3 ZK instances - no problem with recovery.
