### PR TITLE
adding chroot options

### DIFF
--- a/lib/redis_failover/cli.rb
+++ b/lib/redis_failover/cli.rb
@@ -40,6 +40,10 @@ module RedisFailover
           options[:config_file] = file
         end
 
+        opts.on('--with-chroot ROOT', 'Path to ZooKeepers chroot') do |chroot|
+          options[:chroot] = chroot
+        end
+
         opts.on('-E', '--environment ENV', 'Config environment to use') do |config_env|
           options[:config_environment] = config_env
         end

--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -82,7 +82,7 @@ module RedisFailover
     # Configures the ZooKeeper client.
     def setup_zk
       @zk.close! if @zk
-      @zk = ZK.new(@options[:zkservers])
+      @zk = ZK.new("#{@options[:zkservers]}#{@options[:chroot] || ''}")
 
       @zk.register(@manual_znode) do |event|
         @mutex.synchronize do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -36,6 +36,16 @@ module RedisFailover
         opts[:max_failures].should == 1
       end
 
+      it 'properly parses a chroot' do
+        opts = CLI.parse(['-n host:port', '-z localhost:1111', '--with-chroot', '/with/chroot/from/command/line'])
+        opts[:nodes].should == [{
+          :host => 'host',
+          :port => 'port',
+        }]
+
+        opts[:chroot].should == '/with/chroot/from/command/line'
+      end
+
       it 'properly parses the config file' do
         opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/single_environment.yml"])
         opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
@@ -45,6 +55,20 @@ module RedisFailover
 
         opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/multiple_environments.yml", '-E', 'staging'])
         opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
+      end
+
+      it 'properly parses the config file that include chroot' do
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/single_environment_with_chroot.yml"])
+        opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
+        opts[:chroot].should == '/with/chroot'
+
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/multiple_environments_with_chroot.yml", '-E', 'development'])
+        opts[:zkservers].should == 'localhost:2181'
+        opts[:chroot].should == '/with/chroot_development'
+
+        opts = CLI.parse(['-C', "#{File.dirname(__FILE__)}/support/config/multiple_environments_with_chroot.yml", '-E', 'staging'])
+        opts[:zkservers].should == 'zk01:2181,zk02:2181,zk03:2181'
+        opts[:chroot].should == '/with/chroot_staging'
       end
     end
   end

--- a/spec/support/config/multiple_environments_with_chroot.yml
+++ b/spec/support/config/multiple_environments_with_chroot.yml
@@ -1,0 +1,17 @@
+:development:
+  :nodes:
+    - localhost:6379
+    - localhost:6389
+  :zkservers:
+    - localhost:2181
+  :chroot: /with/chroot_development
+
+:staging:
+  :nodes:
+    - redis01:6379
+    - redis02:6379
+  :zkservers:
+    - zk01:2181
+    - zk02:2181
+    - zk03:2181
+  :chroot: /with/chroot_staging

--- a/spec/support/config/single_environment_with_chroot.yml
+++ b/spec/support/config/single_environment_with_chroot.yml
@@ -1,0 +1,8 @@
+:nodes:
+  - redis01:6379
+  - redis02:6379
+:zkservers:
+  - zk01:2181
+  - zk02:2181
+  - zk03:2181
+:chroot: /with/chroot


### PR DESCRIPTION
Hi, ryanlecompte.

I send a new request.

Currently, the radis_node_manager cannot add chroot.
Its chroot can add with command line forcibly, like this.

e.g) redis_node_manager -n xxx,yyyy -z aaa,bbb,ccc/with/chroot

But I need to add a chroot option to ZooKeeper from config file.
Its request can do.

Please merge it if you like.

Thanks
