### PR TITLE
Modified NodeManager to only create its ZK node if it doesn't exist.

### DIFF
--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -314,8 +314,10 @@ module RedisFailover
 
     # Creates the znode path containing the redis nodes.
     def create_path
-      @zk.create(@znode, encode(current_nodes), :ephemeral => true)
-      logger.info("Created ZooKeeper node #{@znode}")
+      unless @zk.exists?(@znode)
+        @zk.create(@znode, encode(current_nodes), :ephemeral => true)
+        logger.info("Created ZooKeeper node #{@znode}")
+      end
     rescue ZK::Exceptions::NodeExists
       # best effort
     end


### PR DESCRIPTION
The #create_path method is called in quite a few places, often when the
node in question already exists. This causes a stream of NodeExists
exceptions from ZooKeeper, which might pollute its logs a bit.

I've modified the method to check if the node exists before creating it.
I didn't write specs, but manual testing showed this doesn't change redis_failover's
behavior.
