### PR TITLE
Prevent Timeout::Error from bringing down the process

### DIFF
--- a/lib/redis_failover/node.rb
+++ b/lib/redis_failover/node.rb
@@ -175,13 +175,13 @@ module RedisFailover
         redis = new_client
         yield redis
       end
-    rescue => ex
+    rescue Exception => ex
       raise NodeUnavailableError, "#{ex.class}: #{ex.message}", ex.backtrace
     ensure
       if redis
         begin
           redis.client.disconnect
-        rescue => ex
+        rescue Exception => ex
           raise NodeUnavailableError, "#{ex.class}: #{ex.message}", ex.backtrace
         end
       end


### PR DESCRIPTION
I observed a problem with the node manager starting when one of the redis hosts is unreachable that resulted in the node manager failing to start:

```
redis_node_manager-god.log:  /usr/lib/ruby/1.8/timeout.rb:64:in `new': execution expired (Timeout::Error)
redis_node_manager-god.log:  from bundle/ruby/1.8/gems/redis_failover-0.9.3/lib/redis_failover/runner.rb:14:in `join'
redis_node_manager-god.log:  from bundle/ruby/1.8/gems/redis_failover-0.9.3/lib/redis_failover/runner.rb:14:in `run'
redis_node_manager-god.log:  from bundle/ruby/1.8/gems/redis_failover-0.9.3/bin/redis_node_manager:6
redis_node_manager-god.log:  from bundle/ruby/1.8/bin/redis_node_manager:19:in `load'
redis_node_manager-god.log:  from bundle/ruby/1.8/bin/redis_node_manager:19
```

The problem is `Timeout::Error` is not a `StandardError`, so it doesn't get caught with the current exception handler.
