### PR TITLE
be smart about picking a master on node manager startup

### DIFF
--- a/lib/redis_failover/errors.rb
+++ b/lib/redis_failover/errors.rb
@@ -25,6 +25,13 @@ module RedisFailover
   class NoMasterError < Error
   end
 
+  # Raised when more than one master is found on startup.
+  class MultipleMastersError < Error
+    def initialize(nodes)
+      super("Multiple nodes with master role: #{nodes.map(&:to_s)}")
+    end
+  end
+
   # Raised when no slave is currently available.
   class NoSlaveError < Error
   end

--- a/lib/redis_failover/node.rb
+++ b/lib/redis_failover/node.rb
@@ -118,7 +118,6 @@ module RedisFailover
     end
     alias_method :eql?, :==
 
-
     # @return [Integer] a hash value for this node
     def hash
       to_s.hash

--- a/spec/node_manager_spec.rb
+++ b/spec/node_manager_spec.rb
@@ -109,7 +109,7 @@ module RedisFailover
       end
     end
 
-    describe '#find_master' do
+    describe '#guess_master' do
       let(:node1) { Node.new(:host => 'node1').extend(RedisStubSupport) }
       let(:node2) { Node.new(:host => 'node2').extend(RedisStubSupport) }
       let(:node3) { Node.new(:host => 'node3').extend(RedisStubSupport) }
@@ -117,19 +117,19 @@ module RedisFailover
       it 'raises error when no master is found' do
         node1.make_slave!(node3)
         node2.make_slave!(node3)
-        expect { manager.find_master([node1, node2]) }.to raise_error(NoMasterError)
+        expect { manager.guess_master([node1, node2]) }.to raise_error(NoMasterError)
       end
 
       it 'raises error when multiple masters found' do
         node1.make_master!
         node2.make_master!
-        expect { manager.find_master([node1, node2]) }.to raise_error(MultipleMastersError)
+        expect { manager.guess_master([node1, node2]) }.to raise_error(MultipleMastersError)
       end
 
       it 'raises error when a node can not be reached' do
         node1.make_master!
         node2.redis.make_unavailable!
-        expect { manager.find_master([node1, node2]) }.to raise_error(NodeUnavailableError)
+        expect { manager.guess_master([node1, node2]) }.to raise_error(NodeUnavailableError)
       end
     end
   end

--- a/spec/node_manager_spec.rb
+++ b/spec/node_manager_spec.rb
@@ -108,5 +108,29 @@ module RedisFailover
         end
       end
     end
+
+    describe '#find_master' do
+      let(:node1) { Node.new(:host => 'node1').extend(RedisStubSupport) }
+      let(:node2) { Node.new(:host => 'node2').extend(RedisStubSupport) }
+      let(:node3) { Node.new(:host => 'node3').extend(RedisStubSupport) }
+
+      it 'raises error when no master is found' do
+        node1.make_slave!(node3)
+        node2.make_slave!(node3)
+        expect { manager.find_master([node1, node2]) }.to raise_error(NoMasterError)
+      end
+
+      it 'raises error when multiple masters found' do
+        node1.make_master!
+        node2.make_master!
+        expect { manager.find_master([node1, node2]) }.to raise_error(MultipleMastersError)
+      end
+
+      it 'raises error when a node can not be reached' do
+        node1.make_master!
+        node2.redis.make_unavailable!
+        expect { manager.find_master([node1, node2]) }.to raise_error(NodeUnavailableError)
+      end
+    end
   end
 end

--- a/spec/support/node_manager_stub.rb
+++ b/spec/support/node_manager_stub.rb
@@ -1,7 +1,7 @@
 module RedisFailover
   class NodeManagerStub < NodeManager
     attr_accessor :master
-    public :current_nodes
+    public :current_nodes, :find_master
 
     def discover_nodes
       # only discover nodes once in testing

--- a/spec/support/node_manager_stub.rb
+++ b/spec/support/node_manager_stub.rb
@@ -2,7 +2,7 @@ module RedisFailover
   class NodeManagerStub < NodeManager
     attr_accessor :master
     # HACK - this will go away once we refactor the tests to use a real ZK/Redis server.
-    public :current_nodes, :find_master
+    public :current_nodes, :guess_master
 
     def discover_nodes
       # only discover nodes once in testing

--- a/spec/support/node_manager_stub.rb
+++ b/spec/support/node_manager_stub.rb
@@ -1,6 +1,7 @@
 module RedisFailover
   class NodeManagerStub < NodeManager
     attr_accessor :master
+    # HACK - this will go away once we refactor the tests to use a real ZK/Redis server.
     public :current_nodes, :find_master
 
     def discover_nodes


### PR DESCRIPTION
This pull request covers a couple ideas that I discussed with @eric today:

When a node manager starts up and the previously known redis master is unknown (i..e, nil in znode config or znode doesn't exist), we will attempt to find the right master. However, we don't want to just pick the first redis node that claims to be a master (i.e., not slaved to another node) since it could generate false positives. The Node Manager now does the following in this pull request:
- if it can't talk to any of the configured redis nodes, it will raise a NodeUnavailableError 
- if it can talk to all the nodes but they all claim to be slaves, it will raise a NoMasterError
- if it can talk to all the nodes but it found more than one master, it will raise a MultipleMastersError

In the above cases, the Node Manager will log the error and attempt to retry the discovery process after a 3 second delay.

When the node manager is in this state, the user should do one of the following:
- perform a manual failover of a specific node via RedisFailover::Client#manual_failover
- manually log into your redis boxes and pick a master using slaveof

Proper synchronization has been added to make sure that we don't have race conditions between discovering nodes, handling a manual failover, and handling a normal state report from a node watcher.
