### PR TITLE
Provide a Client#client stub for Resque interop.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 HEAD
 -----------
 - Improved exception handling in NodeWatcher.
+- Stubbed Client#client to return itself, fixes a fork reconnect bug with Resque (dbalatero)
 
 0.9.1
 -----------

--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -64,6 +64,21 @@ module RedisFailover
       build_clients
     end
 
+    # Stubs this method to return this RedisFailover::Client object.
+    #
+    # Some libraries (Resque) assume they can access the `client` via this method,
+    # but we don't want to actually ever expose the internal Redis connections.
+    #
+    # By returning `self` here, we can add stubs for functionality like #reconnect,
+    # and everything will Just Work.
+    #
+    # Takes an *args array for safety only.
+    #
+    # @return [RedisFailover::Client]
+    def client(*args)
+      self
+    end
+
     # Specifies a callback to invoke when the current redis node list changes.
     #
     # @param [Proc] a callback with current master and slaves as arguments

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -38,6 +38,12 @@ module RedisFailover
       end
     end
 
+    describe '#client' do
+      it 'should return itself as a delegate' do
+        client.client.should == client
+      end
+    end
+
     describe '#dispatch' do
       it 'routes write operations to master' do
         called = false


### PR DESCRIPTION
Allows external libraries to safely call methods like:

```
redis.client.reconnect
```

etc
