### PR TITLE
Catch some zk and zookeeper errors

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -321,6 +321,10 @@ module RedisFailover
       logger.debug { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
       @zk.reopen
       retry
+    rescue Zookeeper::Exceptions::NotConnected, ZK::Exceptions::Retryable => ex
+      logger.warn { "Caught #{ex.class} '#{ex.message}' - retrying" }
+      sleep(RETRY_WAIT_TIME)
+      retry
     end
 
     # Builds new Redis clients for the specified nodes.


### PR DESCRIPTION
Hi there,

I've been getting exceptions like these in fetch_nodes sometimes:

Zookeeper::Exceptions::NotConnected: connection state is closed
Zookeeper::Exceptions::NotConnected: connection state is associating
ZK::Exceptions::OperationTimeOut

Thought it would make sense to catch them and retry, what do you think?
