### PR TITLE
Allow customized logger when using node manager

### DIFF
--- a/lib/redis_failover/cli.rb
+++ b/lib/redis_failover/cli.rb
@@ -44,6 +44,23 @@ module RedisFailover
           options[:chroot] = chroot
         end
 
+        opts.on('-l', '--log-level LEVEL', 'Log level (default: INFO)') do |log_level|
+          options[:log_level] = case log_level.to_s.downcase
+                                when 'debug'
+                                  Logger::DEBUG
+                                when 'info'
+                                  Logger::INFO
+                                when 'warn' 
+                                  Logger::WARN
+                                when 'fatal'
+                                  Logger::FATAL
+                                end
+        end
+
+        opts.on('-L', '--log-file /path/to/file', 'Log file (default: STDOUT)') do |log_file|
+          options[:log_file] = log_file
+        end
+
         opts.on('-E', '--environment ENV', 'Config environment to use') do |config_env|
           options[:config_environment] = config_env
         end

--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -35,6 +35,7 @@ module RedisFailover
     # @option options [Array<String>] :nodes the nodes to manage
     # @option options [String] :max_failures the max failures for a node
     def initialize(options)
+      logger(options[:log_location]) if options[:log_location]
       logger.info("Redis Node Manager v#{VERSION} starting (#{RUBY_DESCRIPTION})")
       @options = options
       @required_node_managers = options.fetch(:required_node_managers, 1)

--- a/lib/redis_failover/util.rb
+++ b/lib/redis_failover/util.rb
@@ -94,15 +94,18 @@ module RedisFailover
     end
 
     # @return [Logger] the logger instance to use
-    def self.logger
-      @logger ||= begin
-        logger = Logger.new(STDOUT)
-        logger.level = Logger::INFO
-        logger.formatter = proc do |severity, datetime, progname, msg|
-          "#{datetime.utc} RedisFailover #{Process.pid} #{severity}: #{msg}\n"
+    def self.logger(location=nil, level=nil)
+      if(@logger.nil? || !location.nil? || !level.nil?)
+        @logger ||= begin
+          logger = Logger.new(location || STDOUT)
+          logger.level = level || Logger::INFO
+          logger.formatter = proc do |severity, datetime, progname, msg|
+            "#{datetime.utc} RedisFailover #{Process.pid} #{severity}: #{msg}\n"
+          end
+          logger
         end
-        logger
       end
+      @logger
     end
 
     # Sets a new logger to use.


### PR DESCRIPTION
Provides extra options to configure where logging output is directed.
