### PR TITLE
if @zk is not connected redis-failover will sit there in an infinite loo...

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -321,6 +321,10 @@ module RedisFailover
       logger.debug { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
       @zk.reopen
       retry
+    rescue Zookeeper::Exceptions::NotConnected => ex 
+      logger.warn { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
+      @zk.reopen
+      retry
     rescue *ZK_ERRORS => ex
       logger.warn { "Caught #{ex.class} '#{ex.message}' - retrying" }
       sleep(RETRY_WAIT_TIME)

--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -58,6 +58,7 @@ module RedisFailover
       @slaves = []
       @node_addresses = {}
       @lock = Monitor.new
+      @shutdown = false
       @current_client_key = "current-client-#{self.object_id}"
       yield self if block_given?
 
@@ -145,8 +146,9 @@ module RedisFailover
     # and then create a new instance of the client. The underlying
     # ZooKeeper client and redis clients will be closed.
     def shutdown
-      @zk.close! if @zk
+      @zk.close! if @zk and @zk.connected?
       @zk = nil
+      @shutdown = true
       purge_clients
     end
 
@@ -154,6 +156,7 @@ module RedisFailover
     # Next, it attempts to reopen the ZooKeeper client and re-create the redis
     # clients after it fetches the most up-to-date list from ZooKeeper.
     def reconnect
+      @shutdown = false
       purge_clients
       @zk ? @zk.reopen : setup_zk
       build_clients
@@ -319,16 +322,22 @@ module RedisFailover
       nodes
     rescue Zookeeper::Exceptions::InheritedConnectionError => ex
       logger.debug { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
-      @zk.reopen
-      retry
+      unless @shutdown
+        @zk.reopen
+        retry
+      end
     rescue Zookeeper::Exceptions::NotConnected => ex 
       logger.warn { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
-      @zk.reopen
-      retry
+      unless @shutdown
+        @zk.reopen
+        retry
+      end
     rescue *ZK_ERRORS => ex
       logger.warn { "Caught #{ex.class} '#{ex.message}' - retrying" }
-      sleep(RETRY_WAIT_TIME)
-      retry
+      unless @shutdown
+        sleep(RETRY_WAIT_TIME)
+        retry
+      end
     end
 
     # Builds new Redis clients for the specified nodes.


### PR DESCRIPTION
...p rather than trying to open the connection

This should fix https://github.com/ryanlecompte/redis_failover/issues/47 but there should be a better way?
