### PR TITLE
Reopen client if an ZK::Exceptions::InterruptedSession occurs

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -317,7 +317,7 @@ module RedisFailover
       logger.debug("Fetched nodes: #{nodes.inspect}")
 
       nodes
-    rescue Zookeeper::Exceptions::InheritedConnectionError => ex
+    rescue Zookeeper::Exceptions::InheritedConnectionError, ZK::Exceptions::InterruptedSession => ex
       logger.debug { "Caught #{ex.class} '#{ex.message}' - reopening ZK client" }
       @zk.reopen
       retry


### PR DESCRIPTION
When an exception that includes `ZK::Exceptions::InterruptedSession` happens (as `Zookeeper::Exceptions::NotConnected`) you need to reopen the client instead of just retrying since retrying on a closed connection will just make it happen again.
