### PR TITLE
Insert the "root_znode" path before "master_redis_node_manager_lock" and expose via accessor

### DIFF
--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -459,6 +459,11 @@ module RedisFailover
       "#{@root_znode}/nodes"
     end
 
+    # @return [String] root path for current node manager lock
+    def current_lock_path
+      "#{@root_znode}/master_redis_node_manager_lock"
+    end
+
     # @return [String] the znode path used for performing manual failovers
     def manual_failover_path
       ManualFailover.path(@root_znode)
@@ -631,7 +636,7 @@ module RedisFailover
 
     # Executes a block wrapped in a ZK exclusive lock.
     def with_lock
-      @zk_lock ||= @zk.locker('master_redis_node_manager_lock')
+      @zk_lock ||= @zk.locker(current_lock_path)
 
       begin
         @zk_lock.lock!(true)


### PR DESCRIPTION
We were having issues while attempting to use the node-manager across two clusters. The first cluster would start up, properly pick master and correctly handle failover however for the second cluster a master would never be promoted and though failover seemed to work the cluster status was not being properly tracked by node-manager.

This fix has been applied to our staging environment and appears to be doing the right thing (now). In attempting to test this I found that there was going to be a lot involved and wanted to get feedback on what would make sense to test, at this point, if anything.
