### PR TITLE
Always include redis-db in client description

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -123,7 +123,7 @@ module RedisFailover
 
     # @return [String] a string representation of the client
     def inspect
-      "#<RedisFailover::Client (master: #{master_name}, slaves: #{slave_names})>"
+      "#<RedisFailover::Client (db: #{@db.to_i}, master: #{master_name}, slaves: #{slave_names})>"
     end
     alias_method :to_s, :inspect
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -54,6 +54,18 @@ module RedisFailover
         called.should be_true
       end
 
+    describe '#inspect' do
+      it 'should always include db' do
+        opts = {:zkservers => 'localhost:1234'}
+        client = ClientStub.new(opts)
+        client.inspect.should match('<RedisFailover::Client \(db: 0,')
+        db = '5'
+        opts.merge!(:db => db)
+        client = ClientStub.new(opts)
+        client.inspect.should match("<RedisFailover::Client \\(db: #{db},")
+      end
+    end
+
       context 'with :master_only false' do
         it 'routes read operations to a slave' do
           called = false


### PR DESCRIPTION
We operate in an environment with multiple databases per redis cluster. While developing and in the production console it is useful to see what database we are currently connected to.

With this patch, calls to "inspect" on "RedisFailover::Client" instances will include the database in the description. I was on the fence about omitting the db when it was nil/zero but decided to keep it in (I went with a hybrid of the "redis-rb" and "redis-cli" output).

I also created a new test in the "client_spec" for this change.  
