### PR TITLE
Define 'call' method on client to enable use with redis-store

### DIFF
--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -36,6 +36,12 @@ module RedisFailover
       end
     end
 
+    def call(command, &block)
+      method = command[0]
+      args = command[1..-1]
+      dispatch(method, *args, &block)
+    end
+
     # Creates a new failover redis client.
     #
     # @param [Hash] options the options used to initialize the client instance

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -66,6 +66,13 @@ module RedisFailover
       end
     end
 
+    describe '#call' do
+      it 'should dispatch :call messages to correct method' do
+        client.should_receive(:dispatch).with(:foo, *['key'])
+        client.call([:foo, 'key'])
+      end
+    end
+
       context 'with :master_only false' do
         it 'routes read operations to a slave' do
           called = false


### PR DESCRIPTION
The redis-store gem implements a caching strategy for Rails, but swapping in RedisFailover::Client for its default standard Redis client results in errors when redis-store tries to use the "call" method, which it expects to be available, and allows it to programmatically invoke a method, passed as a symbol argument.

So this offered solution defines the "call" method for RedisFailover::Client and delegates it to the already existing "dispatch" method.
