### PR TITLE
Make node role verification optional via :verify_role option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The full set of options that can be passed to RedisFailover::Client are:
      :max_retries   - max retries for a failure (default 3)
      :safe_mode     - indicates if safe mode is used or not (default true)
      :master_only   - indicates if only redis master is used (default false)
+     :verify_role   - verify the actual role of a redis node before every command (default true)
 
 The RedisFailover::Client also supports a custom callback that will be invoked whenever the list of redis clients changes. Example usage:
 

--- a/lib/redis_failover/client.rb
+++ b/lib/redis_failover/client.rb
@@ -56,6 +56,7 @@ module RedisFailover
     # @option options [Integer] :max_retries max retries for a failure
     # @option options [Boolean] :safe_mode indicates if safe mode is used or not
     # @option options [Boolean] :master_only indicates if only redis master is used
+    # @option options [Boolean] :verify_role verify the actual role of a redis node before every command
     # @note Use either :zkservers or :zk
     # @return [RedisFailover::Client]
     def initialize(options = {})
@@ -257,7 +258,7 @@ module RedisFailover
     # @raise [NoMasterError] if no master is available
     def master
       if master = @lock.synchronize { @master }
-        verify_role!(master, :master)
+        verify_role!(master, :master) if @verify_role
         return master
       end
       raise NoMasterError
@@ -271,7 +272,7 @@ module RedisFailover
     def slave
       # pick a slave, if none available fallback to master
       if slave = @lock.synchronize { @slaves.shuffle.first }
-        verify_role!(slave, :slave)
+        verify_role!(slave, :slave) if @verify_role
         return slave
       end
       master
@@ -500,6 +501,7 @@ module RedisFailover
       @max_retries = @retry ? options.fetch(:max_retries, 3) : 0
       @safe_mode = options.fetch(:safe_mode, true)
       @master_only = options.fetch(:master_only, false)
+      @verify_role = options.fetch(:verify_role, true)
     end
 
     # @return [String] the znode path for the master redis nodes config

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -120,9 +120,11 @@ module RedisFailover
         client.reconnected.should be_true
       end
 
-      it 'properly detects when a node has changed roles' do
-        client.current_master.change_role_to('slave')
-        expect { client.send(:master) }.to raise_error(InvalidNodeRoleError)
+      context 'with :verify_role true' do
+        it 'properly detects when a node has changed roles' do
+          client.current_master.change_role_to('slave')
+          expect { client.send(:master) }.to raise_error(InvalidNodeRoleError)
+        end
       end
 
       it 'raises error for unsupported operations' do


### PR DESCRIPTION
Not verifying gets rid of redundant INFO query before every redis operation.

Relatedly: Slaves are read-only by default since Redis 2.6, via 'slave-read-only yes' config option, so any invalid writes would be protected anyway.

Note: This is essentially the same as https://github.com/ryanlecompte/redis_failover/pull/44 , but makes verification a config option (defaults to enabled).
