### PR TITLE
No unnecessary znode write

### DIFF
--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -404,16 +404,12 @@ module RedisFailover
     # @note the path will be created if it doesn't exist
     def write_state(path, value, options = {})
       create_path(path, options.merge(:initial_value => value))
-       logger.info("[Debug] Now writing at path #{path}\n")
 	if ( path =~ /nodes/  )
-         logger.info("[Debug] Now I am trying to write node info must be careful\n")      
 	 if ( $previous_value != value ) then
-         logger.info("[Debug] Now I am publishing the node info #{value}\n")
          @zk.set(path, value)
          $previous_value = value
          end
         else
-         logger.info("[Debug] Now I write my own status\n")
 	 @zk.set(path, value)
         end
     end

--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -17,7 +17,7 @@ module RedisFailover
     MAX_PROMOTION_ATTEMPTS = 3
     # Latency threshold for recording node state.
     LATENCY_THRESHOLD = 0.5
-
+    $previous_value=""
     # Errors that can happen during the node discovery process.
     NODE_DISCOVERY_ERRORS = [
       InvalidNodeRoleError,
@@ -404,7 +404,18 @@ module RedisFailover
     # @note the path will be created if it doesn't exist
     def write_state(path, value, options = {})
       create_path(path, options.merge(:initial_value => value))
-      @zk.set(path, value)
+       logger.info("[Debug] Now writing at path #{path}\n")
+	if ( path =~ /nodes/  )
+         logger.info("[Debug] Now I am trying to write node info must be careful\n")      
+	 if ( $previous_value != value ) then
+         logger.info("[Debug] Now I am publishing the node info #{value}\n")
+         @zk.set(path, value)
+         $previous_value = value
+         end
+        else
+         logger.info("[Debug] Now I write my own status\n")
+	 @zk.set(path, value)
+        end
     end
 
     # Handles a manual failover znode update.


### PR DESCRIPTION
Avoid writing the node data in zookeeper when no topology change occurs in the redis master/slaves set.
This allows implementing watchers on the znodes
