### PR TITLE
Recursively create the znode path

### DIFF
--- a/lib/redis_failover/node_manager.rb
+++ b/lib/redis_failover/node_manager.rb
@@ -389,7 +389,8 @@ module RedisFailover
       unless @zk.exists?(path)
         @zk.create(path,
           options[:initial_value],
-          :ephemeral => options.fetch(:ephemeral, false))
+          :ephemeral => options.fetch(:ephemeral, false),
+          :or => :set)
         logger.info("Created ZK node #{path}")
       end
     rescue ZK::Exceptions::NodeExists


### PR DESCRIPTION
In order to keep things clean when running several redis clusters, we would like to be able to place all of our redis failover information under a designated `/redis/<cluster>` path.  However redis_failover fails because zk doesn't recursively create the znode path by default.  

This should fix that problem.

See Also: http://www.rubydoc.info/gems/zk/ZK/Client/Base#create-instance_method
